### PR TITLE
IMU: Add gyro info, update 6-Axis calibration and fix equations

### DIFF
--- a/bluetooth_hid_notes.md
+++ b/bluetooth_hid_notes.md
@@ -106,14 +106,17 @@ Standard full mode - input reports with IMU data instead of subcommand replies. 
 
 If 6-axis sensor is enabled, the IMU data in an 0x30 input report is packaged like this (assuming the packet ID is located at byte -1):
 
-| Byte       | Remarks                                               |
-|:----------:| ----------------------------------------------------- |
-|   12-13    | accel_x (Int16LE). This Axis is reversed in Left JC.  |
-|   14-15    | accel_y (Int16LE)                                     |
-|   16-17    | accel_z (Int16LE). This Axis is reversed in Right JC. |
-|   18-19    | gyro_1 (Int16LE)                                      |
-|   20-21    | gyro_2 (Int16LE)                                      |
-|   22-23    | gyro_3 (Int16LE)                                      |
+| Byte       | Remarks                                                        |
+|:----------:| -------------------------------------------------------------- |
+|   12-13    | accel_x (Int16LE). This Axis is reversed in Left JC.           |
+|   14-15    | accel_y (Int16LE)                                              |
+|   16-17    | accel_z (Int16LE). This Axis is reversed in Right JC.          |
+|   18-19    | gyro_1 (Int16LE)                                               |
+|   20-21    | gyro_2 (Int16LE)                                               |
+|   22-23    | gyro_3 (Int16LE)                                               |
+|   24-47    | The data is repeated 2 more times. Each with 5ms Δt sampling.  |
+
+The 6-Axis data is repeated 3 times. On Joy-con with a 15ms packet push, this is translated to 5ms difference sampling. E.g. 1st sample 0ms, 2nd 5ms, 3rd 10ms. Using all 3 samples let you have a 5ms precision instead of 15ms.
 
 The axes are defined as follows:
 
@@ -133,7 +136,7 @@ The following equation should scale an int16 IMU value into an acceleration vect
 
 where `G_RANGE` is the sensitivity range setting of the accelerometer, as explained [here](http://ozzmaker.com/accelerometer-to-g/).
 
-The Joy-Con are ranged to �8000 MilliGs (G_RANGE = 16000 MilliGs), the sensitivity calibration is always 16384 MilliGs and the SENSOR_RES is 16bit, so the above equation can be simplified to:
+The Joy-Con are ranged to ±8000 MilliGs (G_RANGE = 16000 MilliGs), the sensitivity calibration is always 16384 MilliGs and the SENSOR_RES is 16bit, so the above equation can be simplified to:
 
 `acc_vector_component = acc_raw_component * 0.00025f`. (16384/65535/1000 = 0.00025)
 

--- a/spi_flash_dump_notes.md
+++ b/spi_flash_dump_notes.md
@@ -114,7 +114,7 @@ The OTA FW is not to be confused with the actual Firmware in the 848KB ROM of BC
 
 3 groups of 3 bytes. 
 
-The general code to decode each 3 byte group is:
+The general code to decode each 3 byte group into uint16t_t is:
 ```
 uint16_t data[6]
 data[0] = (stick_cal[1] << 8) & 0xF00 | stick_cal[0];
@@ -161,21 +161,20 @@ uint16_t rstick_y_max = rstick_center_y + data[5];
 
 ## 6-Axis sensor factory and user calibration
 
-4 groups of 3 little endian 16-bit float (in Int16LE encoding).
+4 groups of 3 Int16LE.
 
-Each group probably defines the X Y Z axis.
+Each group defines the X Y Z axis.
 
-Probably Gyroscope.
+1st two groups are Acc cal and the 2nd two groups are Gyro cal.
 
 Sample (Big-Endian):
 
-| 16-bit float #| Sample           | Remarks                                     |
-|:-------------:|:----------------:| ------------------------------------------- |
-| `0` - `2`     | `FFB0 FEB9 00E0` | Possibly XYZ origin position when on table |
-| `3` - `5`     | `4000 4000 4000` | Unknown XYZ                                 |
-| `6` - `8`     | `000E FFDF FFD0` | Unknown XYZ                                 |
-| `9` - `11`    | `343B 343B 343B` | Unknown XYZ                                 |
-
+| int16t_t # | Sample XYZ       | Remarks                                                            |
+|:----------:|:----------------:| ------------------------------------------------------------------ |
+| `0` - `2`  | `FFB0 FEB9 00E0` | Unknown, possibly Acc XYZ origin position.                         |
+| `3` - `5`  | `4000 4000 4000` | Acc XYZ sensitivity range (MilliGs). Default sensitivity: ±8.192G. |
+| `6` - `8`  | `000E FFDF FFD0` | Gyro XYZ origin position when still                                |
+| `9` - `11` | `343B 343B 343B` | Gyro XYZ sensitivity range (dps). Default sensitivity: ±6685dps.   |
 
 ## 6-Axis and Stick device parameters
 
@@ -183,8 +182,8 @@ These follow the same encoding with sensor and stick calibration accordingly.
 
 6-Axis Horizontal Offsets:
 
-3 little endian 16-bit float (in Int16LE encoding).
-Define the origin position when the Joy-Con are held sideways.
+3 Int16LE.
+Define the origin position (Gyro?) when the Joy-Con are held sideways.
 
 Stick Parameters:
 18 bytes that produce 12 uint16_t.


### PR DESCRIPTION
So it seems that Switch do not use standard (e.g. ±8G and ±2000dps) G_RANGE and G_GAIN.

Either way, acc is clamped at ±7.0G and gyro at ±5.0dps.