### PR TITLE
Correct flat surface leveling and add sensor noise ranges

### DIFF
--- a/bluetooth_hid_subcommands_notes.md
+++ b/bluetooth_hid_subcommands_notes.md
@@ -103,11 +103,16 @@ Left_trigger_ms = ((byte[1] << 8) | byte[0]) * 10;
 
 Replies a uint8 with a value of `x01`.
 
-### Subcommand 0x06: Reset connection (Disconnect)
+### Subcommand 0x06: Reset connection (Disconnect/reboot)
 
-Causes the controller to disconnect the Bluetooth connection.
+Causes the controller to disconnect or reboot.
 
-Takes as argument `x00` or `x01`. Sleep, Deep sleep?
+Takes as argument.
+
+| Arg value # | Remarks    |
+|:-----------:|:----------:|
+|   0         | Disconnect |
+|   1         | Reboot     |
 
 ### Subcommand 0x07: Reset pairing info
 
@@ -266,25 +271,25 @@ One argument of `x00` Disable  or `x01` Enable.
 
 Sets the 6-axis sensor sensitivity for accelerometer and gyroscope.
 
-Sending x40 x01 (IMU enable) resets your configuration to default ±8G / 2000dps.
+Sending x40 x01 (IMU enable) resets your configuration to default Â±8G / 2000dps.
 
 Gyroscope sensitivity (Byte 0):
 
 | Arg # | Remarks  |
 |:-----:|:--------:|
-| `00`  | ±250dps  |
-| `01`  | ±500dps  |
-| `02`  | ±1000dps |
-| `03`  | ±2000dps |
+| `00`  | Â±250dps  |
+| `01`  | Â±500dps  |
+| `02`  | Â±1000dps |
+| `03`  | Â±2000dps |
 
 Accelerometer sensitivity (Byte 1):
 
 | Arg # | Remarks |
 |:-----:|:-------:|
-| `00`  | ±8G     |
-| `01`  | ±4G     |
-| `02`  | ±2G     |
-| `03`  | ±16G    |
+| `00`  | Â±8G     |
+| `01`  | Â±4G     |
+| `02`  | Â±2G     |
+| `03`  | Â±16G    |
 
 ### Subcommand 0x42: 6-Axis sensor write
 

--- a/imu_sensor_notes.md
+++ b/imu_sensor_notes.md
@@ -96,19 +96,23 @@ The `cal_acc_horizontal_offset` is always the same. Advise [here](spi_flash_dump
 
 The `cal_acc_coeff` which is used for the equations and it's always `x4000` (`16384`).
 
-Based on these we can conclude on 2 different equations to find the final coefficient:
+Based on these we can conclude on the following equation to find the final coefficient:
 
 ##### Origin posititon is horizontal and stick is upside:
 
 `acc_coeff = (float)(1.0 / (float)(16384 - uint16_to_int16(cal_acc_origin))) * 4.0f;`
 
-##### Origin position is horizontal on flat surface and stick is upside:
-
-`acc_coeff = (float)(1.0 / (float)(16384 - uint16_to_int16(cal_acc_origin + cal_acc_horizontal_offset))) * 4.0f;`
-
 Then we use the coefficient to convert the value into G (SI: 9.8m/s²):
 
 `acc_vector_component = acc_raw_component * acc_coeff`
+
+### Completely level* Accelerometer when horizontal on flat surface:
+
+*This will level the accelerometer to 0 values when resting on flat surface
+
+We subtract `cal_acc_horizontal_offset` and then we use the coefficient to convert the value into G (SI: 9.8m/s²):
+
+`acc_vector_component = (acc_raw_component - uint16_to_int16(cal_acc_horizontal_offset)) * acc_coeff`
 
 ### Gyroscope (Calibrated) - Rotation (in Degrees/s - dps)
 
@@ -137,3 +141,27 @@ Then we use the coefficient to convert the value into degrees°/s (SI: 0.01745 r
 The equation will become:
 
 `acc_vector_component = acc_raw_component * acc_coeff * 0.0027777778`
+
+## Noise level range for each sensitivity configuration
+
+This is useful to set a noise cancellation deadzone for acc and gyro.
+
+Based on official values. Also it's a range value (not a ± value).
+
+Accelerometer:
+
+| Sensitivity   | Noise level range |
+|:-------------:|:-----------------:|
+| ±2G           | 328 * 2.5 = 2050  |
+| ±4G           | 164 * 2.5 = 410   |
+| ±8G (default) | 82 * 2.5 = 205    |
+| ±16G          | No official value |
+
+Gyroscope:
+
+| Sensitivity        | Noise level range |
+|:------------------:|:-----------------:|
+| ±250dps            | 236 * 2.5 = 590   |
+| ±500dps            | 118 * 2.5 = 295   |
+| ±1000dps           | 59 * 2.5 = 147    |
+| ±2000dps (default) | 30 * 2.5 = 75     |


### PR DESCRIPTION
The flat surface equation was wrong and also used wrong.

Corrected to it's proper usage:
It's to completely level the acc to almost zero values when resting on a flat surface. It also removes gravity force in the Z axis with the above conditions. Not to be used in normal conditions.

The noise ranges are official values and can be used to cancel out the jitter showcased from the sensor.

Lastly, update x06 subcommand