### PR TITLE
Precursor for the upcoming NFC/IR MCU changes

### DIFF
--- a/bluetooth_hid_notes.md
+++ b/bluetooth_hid_notes.md
@@ -26,7 +26,7 @@ See "Rumble data" below.
 
 ### OUTPUT 0x03
 
-MCU FW Update packet
+NFC/IR MCU FW Update packet.
 
 ### OUTPUT 0x10
 
@@ -34,7 +34,7 @@ Rumble only. See OUTPUT 0x01 and "Rumble data" below.
 
 ### OUTPUT 0x11
 
-Command to MCU.
+Request specific data from the NFC/IR MCU. Can also send rumble.
 
 ### OUTPUT 0x12
 
@@ -71,7 +71,7 @@ This input packet is pushed to the host when a button is pressed or released, an
 
 |  Byte # |        Sample value        | Remarks                   |
 |:-------:|:--------------------------:|:-------------------------:|
-|  0      | `x3F`                      | Header, same as report ID |
+|  0      | `x3F`                      | Input report ID           |
 |  1-2    | `x28 CA`                   | Button status             |
 |  3      | `x08`                      | Stick hat data            |
 |  4-11   | `x00 80 00 80 00 80 00 80` | Filler data               |
@@ -99,7 +99,7 @@ Standard input reports used for subcommand replies.
 
 ### INPUT 0x23
 
-MCU FW update input report.
+NFC/IR MCU FW update input report.
 
 ### INPUT 0x30
 
@@ -107,7 +107,7 @@ Standard full mode - input reports with IMU data instead of subcommand replies. 
 
 ### INPUT 0x31
 
-NFC/IR Mode. Pushes large packets with standard input report + NFC/IR input report.
+NFC/IR MCU mode. Pushes large packets with standard input report + NFC/IR MCU data input report.
 
 ### INPUT 0x32
 
@@ -188,7 +188,7 @@ Enables FW update. Unlocks Erase/Write memory commands.
 
 The buffer sent must be exactly one byte. If else, Joy-Con rejects it.
 
-The only possible ways to send it, is a Linux device with patched hidraw to accept 1 byte reports or a custom bluetooth development kit. 
+The only possible ways to send it, is a Linux device with patched hidraw to accept 1 byte reports, directly through l2cap or a custom bluetooth development kit. 
 
 | Byte # |  Sample   | Remarks                        |
 |:------:|:---------:| ------------------------------ |

--- a/bluetooth_hid_notes.md
+++ b/bluetooth_hid_notes.md
@@ -124,31 +124,31 @@ The middle byte is shared between the controllers.
 
 (Note: in the following table, the byte with the packet ID is included and located at byte "0".)
 
-|   Byte #          |        Sample         | Remarks                                                                             |
-|:-----------------:|:---------------------:| ----------------------------------------------------------------------------------- |
-| 0                 | `x21`, `x30`, `x31`   | Input report ID                                                                     |
-| 1                 | `00` - `FF`           | Timer. Increments very fast. Can be used to estimate excess Bluetooth latency.      |
-| 2 high nibble     | `0` - `9`             | Battery level. 8=full, 6=medium, 4=low, 2=critical, 0=empty. LSB=Charging.          |
-| 2 low nibble      | `x0`, `x1`, `xE`      | Connection info. `(con_info >> 1) & 3` - 3=JC, 0=Pro/ChrGrip. `con_info & 1` - 1=Switch/USB powered. |
-| 3, 4, 5           | `41 00 82`            | Button status (see below table)                                                     |
-| 6, 7, 8           | --                    | Left analog stick data                                                              |
-| 9, 10, 11         | --                    | Right analog stick data                                                             |
-| 12                | `70`, `C0`, `B0`      | Vibrator input report. Decides if next vibration pattern should be sent.            |
-| 13  (ID `21`)     | `00`, `80`, `90`, `82`| ACK byte for subcmd reply. ACK: MSB is `1`, NACK: MSB is `0`. If reply is ACK and has data, `byte12 & 0x7F` gives as the type of data. If simple ACK or NACK, the data type portion is `x00` |
-| 14  (ID `21`)     | `02`, `10`, `03`      | Reply-to subcommand ID. The subcommand ID is used as-is.                            |
-| 15-49  (ID `21`)  | --                    | Subcommand reply data. Max 35 bytes (excludes 2 byte subcmd ack above).             |
-| 13-49  (ID `23`)  | --                    | NFC/IR MCU FW update input report. Max 37 bytes.                                    |
-| 13-48  (ID `30`, `31`, `32`, `33`) | --   | 6-Axis data. 3 frames of 2 groups of 3 Int16LE each. Group is Acc followed by Gyro. |
-| 49-361  (ID `31`) | --                    | NFC/IR data input report. Max 313 bytes.                                            |
+|   Byte #           |        Sample         | Remarks                                                                             |
+|:------------------:|:---------------------:| ----------------------------------------------------------------------------------- |
+| 0                  | `x21`, `x30`, `x31`   | Input report ID                                                                     |
+| 1                  | `x00` - `xFF`         | Timer. Increments very fast. Can be used to estimate excess Bluetooth latency.      |
+| 2 high nibble      | `0` - `9`             | Battery level. 8=full, 6=medium, 4=low, 2=critical, 0=empty. LSB=Charging.          |
+| 2 low nibble       | `x0`, `x1`, `xE`      | Connection info. `(con_info >> 1) & 3` - 3=JC, 0=Pro/ChrGrip. `con_info & 1` - 1=Switch/USB powered. |
+| 3, 4, 5            | `x41 00 82`           | Button status (see below table)                                                     |
+| 6, 7, 8            | --                    | Left analog stick data                                                              |
+| 9, 10, 11          | --                    | Right analog stick data                                                             |
+| 12                 | `x70`, `xC0`, `xB0`   | Vibrator input report. Decides if next vibration pattern should be sent.            |
+| 13  (ID `x21`)     | `x00`, `x80`, `x90`, `x82`| ACK byte for subcmd reply. ACK: MSB is `1`, NACK: MSB is `0`. If reply is ACK and has data, `byte12 & 0x7F` gives as the type of data. If simple ACK or NACK, the data type portion is `x00` |
+| 14  (ID `x21`)     | `x02`, `x10`, `x03`   | Reply-to subcommand ID. The subcommand ID is used as-is.                            |
+| 15-49  (ID `x21`)  | --                    | Subcommand reply data. Max 35 bytes (excludes 2 byte subcmd ack above).             |
+| 13-49  (ID `x23`)  | --                    | NFC/IR MCU FW update input report. Max 37 bytes.                                    |
+| 13-48  (ID `x30`, `x31`, `x32`, `x33`) | -- | 6-Axis data. 3 frames of 2 groups of 3 Int16LE each. Group is Acc followed by Gyro. |
+| 49-361  (ID `x31`) | --                    | NFC/IR data input report. Max 313 bytes.                                            |
 
 (Note2: In the `21` input reports, the byte13 (ACK byte) can be parsed as follows: `byte13 >> 7` tells us if it's an ACK or NACK. If it's an ACK, check `byte13 & 0x7F` to see what type of data it has. If it is a simple ACK, the byte13 is `x80` and thus the type of data is `x00`. If we expect a certain order of received packets, we can hardcode these byte13 values. If it's a NACK, the byte13 is always `x00`)
 
 #### Standard input report - buttons
-| Byte       | Bit `01` | `02` | `04`    | `08`    | `10` | `20`    | `40` | `80`          |
-|:----------:|:--------:|:----:|:-------:|:-------:|:----:|:-------:|:----:|:-------------:|
-| 3 (Right)  | Y        | X    | B       | A       | SR   | SL      | R    | ZR            |
-| 4 (Shared) | Minus    | Plus | R Stick | L Stick | Home | Capture | --   | Charging Grip |
-| 5 (Left)   | Down     | Up   | Right   | Left    | SR   | SL      | L    | ZL            |
+| Byte       | Bit `x01` | `x02` | `x04`    | `x08`    | `x10` | `x20`    | `x40` | `x80`         |
+|:----------:|:---------:|:-----:|:--------:|:--------:|:-----:|:--------:|:-----:|:-------------:|
+| 3 (Right)  | Y         | X     | B        | A        | SR    | SL       | R     | ZR            |
+| 4 (Shared) | Minus     | Plus  | R Stick  | L Stick  | Home  | Capture  | --    | Charging Grip |
+| 5 (Left)   | Down      | Up    | Right    | Left     | SR    | SL       | L     | ZL            |
 
 Note that the button status of the L and R Joy-Cons can be ORed together to get a complete button status.
 

--- a/bluetooth_hid_notes.md
+++ b/bluetooth_hid_notes.md
@@ -119,35 +119,36 @@ Unknown. Sends standard input reports.
 
 #### Standard input report format
 
-The 2nd byte belongs entirely to the Right Joy-Con, while the 4th byte belongs entirely to the Left Joy-Con.
+The 3rd byte belongs entirely to the Right Joy-Con, while the 5th byte belongs entirely to the Left Joy-Con.
 The middle byte is shared between the controllers.
 
-(Note: in the following table, the byte with the packet ID is cut off, located at byte "-1".)
+(Note: in the following table, the byte with the packet ID is included and located at byte "0".)
 
 |   Byte #          |        Sample         | Remarks                                                                             |
 |:-----------------:|:---------------------:| ----------------------------------------------------------------------------------- |
-| 0                 | `00` - `FF`           | Timer. Increments very fast. Can be used to estimate excess Bluetooth latency.      |
-| 1 high nibble     | `0` - `9`             | Battery level. 8=full, 6=medium, 4=low, 2=critical, 0=empty. LSB=Charging.          |
-| 1 low nibble      | `x0`, `x1`, `xE`      | Connection info. `(con_info >> 1) & 3` - 3=JC, 0=Pro/ChrGrip. `con_info & 0x1` - 1=Switch/USB powered. |
-| 2, 3, 4           | `41 00 82`            | Button status (see below table)                                                     |
-| 5, 6, 7           | --                    | Left analog stick data                                                              |
-| 8, 9, 10          | --                    | Right analog stick data                                                             |
-| 11                | `70`, `C0`, `B0`      | Vibrator input report. Decides if next vibration pattern should be sent.            |
-| 12  (ID `21`)     | `00`, `80`, `90`, `82`| ACK byte for subcmd reply. ACK: MSB is `1`, NACK: MSB is `0`. If reply is ACK and has data, `byte12 & 0x7F` gives as the type of data. If simple ACK or NACK, the data type portion is `x00` |
-| 13  (ID `21`)     | `02`, `10`, `03`      | Reply-to subcommand ID. The subcommand ID is used as-is.                            |
-| 14-48  (ID `21`)  | --                    | Subcommand reply data. Max 35 bytes (excludes 2 byte subcmd ack above).             |
-| 12-48  (ID `23`)  | --                    | MCU FW update input report. Max 37 bytes.                                           |
-| 12-47  (ID `30`, `31`, `32`, `33`) | --   | 6-Axis data. 3 frames of 2 groups of 3 Int16LE each. Group is Acc followed by Gyro. |
-| 48-360  (ID `31`) | --                    | NFC/IR input report. Max 313 bytes.                                                 |
+| 0                 | `x21`, `x30`, `x31`   | Input report ID                                                                     |
+| 1                 | `00` - `FF`           | Timer. Increments very fast. Can be used to estimate excess Bluetooth latency.      |
+| 2 high nibble     | `0` - `9`             | Battery level. 8=full, 6=medium, 4=low, 2=critical, 0=empty. LSB=Charging.          |
+| 2 low nibble      | `x0`, `x1`, `xE`      | Connection info. `(con_info >> 1) & 3` - 3=JC, 0=Pro/ChrGrip. `con_info & 1` - 1=Switch/USB powered. |
+| 3, 4, 5           | `41 00 82`            | Button status (see below table)                                                     |
+| 6, 7, 8           | --                    | Left analog stick data                                                              |
+| 9, 10, 11         | --                    | Right analog stick data                                                             |
+| 12                | `70`, `C0`, `B0`      | Vibrator input report. Decides if next vibration pattern should be sent.            |
+| 13  (ID `21`)     | `00`, `80`, `90`, `82`| ACK byte for subcmd reply. ACK: MSB is `1`, NACK: MSB is `0`. If reply is ACK and has data, `byte12 & 0x7F` gives as the type of data. If simple ACK or NACK, the data type portion is `x00` |
+| 14  (ID `21`)     | `02`, `10`, `03`      | Reply-to subcommand ID. The subcommand ID is used as-is.                            |
+| 15-49  (ID `21`)  | --                    | Subcommand reply data. Max 35 bytes (excludes 2 byte subcmd ack above).             |
+| 13-49  (ID `23`)  | --                    | NFC/IR MCU FW update input report. Max 37 bytes.                                    |
+| 13-48  (ID `30`, `31`, `32`, `33`) | --   | 6-Axis data. 3 frames of 2 groups of 3 Int16LE each. Group is Acc followed by Gyro. |
+| 49-361  (ID `31`) | --                    | NFC/IR data input report. Max 313 bytes.                                            |
 
-(Note2: In the `21` input reports, the byte12 (ACK byte) can be parsed as follows: `byte12 >> 7` tells us if it's an ACK or NACK. If it's an ACK, check `byte12 & 0x7F` to see what type of data it has. If it is a simple ACK, the byte12 is `x80` and thus the type of data is `x00`. If we expect a certain order of received packets, we can hardcode these byte12 values. If it's a NACK, the byte12 is always `x00`)
+(Note2: In the `21` input reports, the byte13 (ACK byte) can be parsed as follows: `byte13 >> 7` tells us if it's an ACK or NACK. If it's an ACK, check `byte13 & 0x7F` to see what type of data it has. If it is a simple ACK, the byte13 is `x80` and thus the type of data is `x00`. If we expect a certain order of received packets, we can hardcode these byte13 values. If it's a NACK, the byte13 is always `x00`)
 
 #### Standard input report - buttons
 | Byte       | Bit `01` | `02` | `04`    | `08`    | `10` | `20`    | `40` | `80`          |
 |:----------:|:--------:|:----:|:-------:|:-------:|:----:|:-------:|:----:|:-------------:|
-| 2 (Right)  | Y        | X    | B       | A       | SR   | SL      | R    | ZR            |
-| 3 (Shared) | Minus    | Plus | R Stick | L Stick | Home | Capture | --   | Charging Grip |
-| 4 (Left)   | Down     | Up   | Right   | Left    | SR   | SL      | L    | ZL            |
+| 3 (Right)  | Y        | X    | B       | A       | SR   | SL      | R    | ZR            |
+| 4 (Shared) | Minus    | Plus | R Stick | L Stick | Home | Capture | --   | Charging Grip |
+| 5 (Left)   | Down     | Up   | Right   | Left    | SR   | SL      | L    | ZL            |
 
 Note that the button status of the L and R Joy-Cons can be ORed together to get a complete button status.
 
@@ -156,7 +157,7 @@ Note that the button status of the L and R Joy-Cons can be ORed together to get 
 The code below properly decodes the stick data:
 
 ```
-uint8_t *data = packet + (left ? 5 : 8);
+uint8_t *data = packet + (left ? 6 : 9);
 uint16_t stick_horizontal = data[0] | ((data[1] & 0xF) << 8);
 uint16_t stick_vertical = (data[1] >> 4) | (data[2] << 4);
 ```

--- a/bluetooth_hid_notes.md
+++ b/bluetooth_hid_notes.md
@@ -47,14 +47,14 @@ A timing byte, then 4 bytes of rumble data for left Joy-Con, followed by 4 bytes
 The rumble data structure contains 2 bytes High Band data, 2 byte Low Band data.
 The values for HF Band frequency and LF amplitude are encoded.
 
-|  Byte #  |        Range                             | Remarks |
-|:--------:|:----------------------------------------:| ------------------------------------------------------------------------ |
-| 0, 4     | `04` - `FC` (81.75Hz - 313.14Hz)         | High Band Lower Frequency. Steps `+0x0004`.                              |
-| 0-1, 4-5 | `00 01` - `FC 01` (320.00Hz - 1252.57Hz) | Byte `1`,`5` LSB enables High Band Higher Frequency. Steps `+0x0400`.    |
-| 1, 5     | `00 00` - `C8 00` (0.0f - 1.0f)          | High Band Amplitude. Steps `+0x0200`. Real max: `FE`.                    |
-| 2, 6     | `01` - `7F` (40.87Hz - 626.28Hz)         | Low Band Frequency.                                                      |
-| 3, 7     | `40` - `72` (0.0f - 1.0f)                | Low Band Amplitude. Safe max: `00 72`.                                   |
-| 2-3, 6-7 | `80 40` - `80 71` (0.01f - 0.98f)        | Byte `2`,`6` +0x80 enables intermediate LF amplitude. Real max: `80 FF`. |
+|  Byte #  |        Range                               | Remarks                                                                  |
+|:--------:|:------------------------------------------:| ------------------------------------------------------------------------ |
+| 0, 4     | `x04` - `xFC` (81.75Hz - 313.14Hz)         | High Band Lower Frequency. Steps `+0x0004`.                              |
+| 0-1, 4-5 | `x00 01` - `xFC 01` (320.00Hz - 1252.57Hz) | Byte `1`,`5` LSB enables High Band Higher Frequency. Steps `+0x0400`.    |
+| 1, 5     | `x00 00` - `xC8 00` (0.0f - 1.0f)          | High Band Amplitude. Steps `+0x0200`. Real max: `FE`.                    |
+| 2, 6     | `x01` - `x7F` (40.87Hz - 626.28Hz)         | Low Band Frequency.                                                      |
+| 3, 7     | `x40` - `x72` (0.0f - 1.0f)                | Low Band Amplitude. Safe max: `00 72`.                                   |
+| 2-3, 6-7 | `x80 40` - `x80 71` (0.01f - 0.98f)        | Byte `2`,`6` +0x80 enables intermediate LF amplitude. Real max: `80 FF`. |
  
 For a rumble values table, example and the algorithm for frequency, check rumble_data_table.md.
 
@@ -69,12 +69,12 @@ These safe amplitude ranges are defined by Switch HID library.
 
 This input packet is pushed to the host when a button is pressed or released, and provides the "normal controller" interface for the OS.
 
-|  Byte # |        Sample value       | Remarks                   |
-|:-------:|:-------------------------:|:-------------------------:|
-|  0      | `3F`                      | Header, same as report ID |
-|  1-2    | `28 CA`                   | Button status             |
-|  3      | `08`                      | Stick hat data            |
-|  4-11   | `00 80 00 80 00 80 00 80` | Filler data               |
+|  Byte # |        Sample value        | Remarks                   |
+|:-------:|:--------------------------:|:-------------------------:|
+|  0      | `x3F`                      | Header, same as report ID |
+|  1-2    | `x28 CA`                   | Button status             |
+|  3      | `x08`                      | Stick hat data            |
+|  4-11   | `x00 80 00 80 00 80 00 80` | Filler data               |
 
 #### Stick hat data
 
@@ -88,10 +88,10 @@ Hold your controller sideways so that SL, SYNC, and SR line up with the screen. 
 
 #### Button status format
 
-| Byte | Bit `01` | `02`  |`04`        |`08`         |`10`  |`20`     |`40`   |`80`     |
-|:----:|:--------:|:-----:|:-----------|:-----------:|:----:|:-------:|:-----:|:-------:|
-| 1    | Down     | Right | Left       | Up          | SL   | SR      | --    | --      |
-| 2    | Minus    | Plus  | Left Stick | Right Stick | Home | Capture | L / R | ZL / ZR |
+| Byte | Bit `x01` | `x02`  |`x04`        |`x08`         |`x10`  |`x20`     |`x40`   |`x80`     |
+|:----:|:---------:|:------:|:------------|:------------:|:-----:|:--------:|:------:|:--------:|
+| 1    | Down      | Right  | Left        | Up           | SL    | SR       | --     | --       |
+| 2    | Minus     | Plus   | Left Stick  | Right Stick  | Home  | Capture  | L / R  | ZL / ZR  |
 
 ### INPUT 0x21
 
@@ -189,9 +189,9 @@ The buffer sent must be exactly one byte. If else, Joy-Con rejects it.
 
 The only possible ways to send it, is a Linux device with patched hidraw to accept 1 byte reports or a custom bluetooth development kit. 
 
-| Byte # |  Sample  | Remarks                        |
-|:------:|:--------:| ------------------------------ |
-| 0      | `70`     | Feature report                 |
+| Byte # |  Sample   | Remarks                        |
+|:------:|:---------:| ------------------------------ |
+| 0      | `x70`     | Feature report ID              |
 
 ### FEATURE 0x71: Setup memory read
 
@@ -199,34 +199,34 @@ The only possible ways to send it, is a Linux device with patched hidraw to acce
 
 Prepares the SPI Read report with the requested address and size.
 
-| Byte # |  Sample       | Remarks                        |
-|:------:|:-------------:| ------------------------------ |
-| 0      | `71`          | Feature report                 |
-| 1 - 4  | `F4 1F 00 F8` | UInt32LE address               |
-| 5 - 6  | `08 00`       | UInt16LE size. Max xF9 bytes.  |
-| 7      | `7C`          | Checksum (8-bit 2s Complement) |
+| Byte # |  Sample        | Remarks                        |
+|:------:|:--------------:| ------------------------------ |
+| 0      | `x71`          | Feature report ID              |
+| 1 - 4  | `xF4 1F 00 F8` | UInt32LE address               |
+| 5 - 6  | `x08 00`       | UInt16LE size. Max xF9 bytes.  |
+| 7      | `x7C`          | Checksum (8-bit 2s Complement) |
 
 The checksum is calculated as `0x100 - Sum of Bytes`.
 
 Memory map:
 
-| Address #   |  Size   | Remarks                |
-|:-----------:|:-------:| ---------------------- |
-| `x00000000` | `C8000` | ROM region 1 (800KB)   |
-| `x000D0000` | `10000` | RAM region 1 (64KB)    |
-| `x00200000` | `48000` | RAM region 2 (288KB)   |
-| `x00260000` | `C000`  | ROM region 2 (48KB)    |
-| `xF8000000` | `80000` | SPI (512KB, fully R/W) |
+| Address #   |  Size    | Remarks                |
+|:-----------:|:--------:| ---------------------- |
+| `x00000000` | `xC8000` | ROM region 1 (800KB)   |
+| `x000D0000` | `x10000` | RAM region 1 (64KB)    |
+| `x00200000` | `x48000` | RAM region 2 (288KB)   |
+| `x00260000` | `xC000`  | ROM region 2 (48KB)    |
+| `xF8000000` | `x80000` | SPI (512KB, fully R/W) |
 
 ### FEATURE 0x72: Memory read
 
 [Get] feature Report
 
-| Byte # |  Sample  | Remarks                         |
-|:------:|:--------:| ------------------------------- |
-| 0      | `72`     | Feature report                  |
-| 1      | `8E`     | Checksum* (8-bit 2s Complement) |
-| 2-EOF  |          |                                 |
+| Byte # |  Sample   | Remarks                         |
+|:------:|:---------:| ------------------------------- |
+| 0      | `x72`     | Feature report ID               |
+| 1      | `x8E`     | Checksum* (8-bit 2s Complement) |
+| 2-EOF  |           |                                 |
 
 *Checksum is optional.
 
@@ -236,13 +236,13 @@ If the 0x71 command wasn't sent previously, it will return zeroed data (except I
 
 The data returned has the following structure:
 
-| Byte #  |  Sample       | Remarks                        |
-|:-------:|:-------------:| ------------------------------ |
-| 0       | `74`          | Feature report                 |
-| 1 - 4   | `00 80 02 F8` | UInt32LE address               |
-| 5 - 6   | `F9 00`       | UInt16LE size                  |
-| 7-EOF-1 |               | Data requested                 |
-| EOF     | `DC`          | Checksum (8-bit 2s Complement) |
+| Byte #  |  Sample        | Remarks                        |
+|:-------:|:--------------:| ------------------------------ |
+| 0       | `x74`          | Feature report ID              |
+| 1 - 4   | `x00 80 02 F8` | UInt32LE address               |
+| 5 - 6   | `xF9 00`       | UInt16LE size                  |
+| 7-EOF-1 |                | Data requested                 |
+| EOF     | `xDC`          | Checksum (8-bit 2s Complement) |
 
 The returned size is header + size in 0x71 ft report + 1. So make sure to get your report with an adequate buffer size.
 
@@ -256,12 +256,12 @@ Should be used only with SPI (0xF8000000 - 0xF807FFFF), because SPI needs to be 
 
 0x70 command must be sent before using this. Otherwise, Joy-Con will reply with invalid report ID.
 
-| Byte # |  Sample       | Remarks                        |
-|:------:|:-------------:| ------------------------------ |
-| 0      | `73`          | Feature report                 |
-| 1 - 4  | `00 80 02 F8` | UInt32LE address               |
-| 5 - 6  | `00 10`       | UInt16LE size.                 |
-| 7      | `03`          | Checksum (8-bit 2s Complement) |
+| Byte # |  Sample        | Remarks                        |
+|:------:|:--------------:| ------------------------------ |
+| 0      | `x73`          | Feature report ID              |
+| 1 - 4  | `x00 80 02 F8` | UInt32LE address               |
+| 5 - 6  | `x00 10`       | UInt16LE size.                 |
+| 7      | `x03`          | Checksum (8-bit 2s Complement) |
 
 This command only checks `& 0x00FFF000` to acquire the sector number. Size is also irrelevant, but it's best to use values `x01 - x100`.
 
@@ -279,13 +279,13 @@ Writes to SPI. Can write locked sectors.
 
 0x70 command must be sent before using this. Otherwise, Joy-Con will reply with invalid report ID.
 
-| Byte #  |  Sample       | Remarks                        |
-|:-------:|:-------------:| ------------------------------ |
-| 0       | `74`          | Feature report                 |
-| 1 - 4   | `00 80 02 F8` | UInt32LE address               |
-| 5 - 6   | `F9 00`       | UInt16LE size. Max xF9 bytes.  |
-| 7-EOF-1 |               | Data to write                  |
-| EOF     | `DC`          | Checksum (8-bit 2s Complement) |
+| Byte #  |  Sample        | Remarks                        |
+|:-------:|:--------------:| ------------------------------ |
+| 0       | `x74`          | Feature report ID              |
+| 1 - 4   | `x00 80 02 F8` | UInt32LE address               |
+| 5 - 6   | `xF9 00`       | UInt16LE size. Max xF9 bytes.  |
+| 7-EOF-1 |                | Data to write                  |
+| EOF     | `xDC`          | Checksum (8-bit 2s Complement) |
 
 #### Warning:
 
@@ -301,13 +301,13 @@ If address is `x0000` the Host should assume that the device will reboot.
 
 0x70 command must be sent before using this. Otherwise, Joy-Con will reply with invalid report ID.
 
-| Byte #  |  Sample       | Remarks                                  |
-|:-------:|:-------------:| ---------------------------------------- |
-| 0       | `75`          | Feature report                           |
-| 1 - 4   | `00 80 02 F8` | UInt32LE entry address for firmware jump |
-| 5 - 6   | `04 00`       | UInt16LE size. Always 4.                 |
-| 7       | `00 80 02 F8` | UInt32LE entry address for firmware jump |
-| 8       | `DC`          | Checksum (8-bit 2s Complement)           |
+| Byte #  |  Sample        | Remarks                                  |
+|:-------:|:--------------:| ---------------------------------------- |
+| 0       | `x75`          | Feature report ID                        |
+| 1 - 4   | `x00 80 02 F8` | UInt32LE entry address for firmware jump |
+| 5 - 6   | `x04 00`       | UInt16LE size. Always 4.                 |
+| 7       | `x00 80 02 F8` | UInt32LE entry address for firmware jump |
+| 8       | `xDC`          | Checksum (8-bit 2s Complement)           |
 
 Sending x75 00000000 0400 00000000 CRC will reboot the device and load the bootrom at 0x0. This is a good practice after finishing erasing/writing proccess.
 

--- a/bluetooth_hid_subcommands_notes.md
+++ b/bluetooth_hid_subcommands_notes.md
@@ -8,7 +8,7 @@ All subcommands that do nothing, reply back with ACK `x80##` and `x03`
 
 Replies with `x8000` `x03`
 
-Can be used to get Controller state only (w/o 6-Axis sensor data), like any subcommand that does nothing
+Does nothing actually, but can be used to get Controller state only (w/o 6-Axis sensor data), like any subcommand that does nothing.
 
 ### Subcommand 0x01: Bluetooth manual pairing
 
@@ -56,7 +56,7 @@ Response data after 02 command byte:
 
 | Byte # | Sample               | Remarks                                                  |
 |:------:|:--------------------:| -------------------------------------------------------- |
-|  0-1   | `x03 48`             | Firmware Version. Latest is 3.86 (from 4.0.0 and up).    |
+|  0-1   | `x03 48`             | Firmware Version. Latest is 3.89 (from 5.0.0 and up).    |
 |  2     | `x01`                | 1=Left Joy-Con, 2=Right Joy-Con, 3=Pro Controller.       |
 |  3     | `x02`                | Unknown. Seems to be always `02`                         |
 |  4-9   | `x7C BB 8A EA 30 57` | Joy-Con MAC address in Big Endian                        |
@@ -67,19 +67,20 @@ Response data after 02 command byte:
 
 One argument:
 
-| Argument # | Remarks                                                                                          |
-|:----------:| ------------------------------------------------------------------------------------------------ |
-|   `00`     | Used with cmd `x11`. Active polling for IR camera data. 0x31 data format must be set first       |
-|   `01`     | Same as `00`                                                                                     |
-|   `02`     | Same as `00`. Active polling mode for IR camera data. For specific IR modes                      |
-|   `23`     | MCU update state report?                                                                         |
-|   `30`     | Standard full mode. Pushes current state @60Hz                                                   |
-|   `31`     | NFC/IR mode. Pushes large packets @60Hz                                                          |
-|   `33`     | Unknown mode.                                                                                    |
-|   `35`     | Unknown mode.                                                                                    |
-|   `3F`     | Simple HID mode. Pushes updates with every button press                                          |
+| Arg #  | Remarks                                                                                          |
+|:------:| ------------------------------------------------------------------------------------------------ |
+|  `x00` | Used with cmd `x11`. Active polling for NFC/IR camera data. 0x31 data format must be set first.  |
+|  `x01` | Same as `00`. Active polling mode for NFC/IR MCU configuration data.                             |
+|  `x02` | Same as `00`. Active polling mode for NFC/IR data and configuration. For specific NFC/IR modes   |
+|  `x03` | Same as `00`. Active polling mode for IR camera data. For specific IR modes                      |
+|  `x23` | MCU update state report?                                                                         |
+|  `x30` | Standard full mode. Pushes current state @60Hz                                                   |
+|  `x31` | NFC/IR mode. Pushes large packets @60Hz                                                          |
+|  `x33` | Unknown mode.                                                                                    |
+|  `x35` | Unknown mode.                                                                                    |
+|  `x3F` | Simple HID mode. Pushes updates with every button press                                          |
 
-`31` input report has all zeroes for IR/NFC data if a `11` ouput report with subcmd `03 00` or `03 01` or `03 02` was not sent before.
+`x31` input report has all zeroes for IR/NFC data if a `11` ouput report with subcmd `03 00/01/02/03` was not sent before.
 
 ### Subcommand 0x04: Trigger buttons elapsed time
 
@@ -170,9 +171,9 @@ Replies with `x8011` ack and a uint8 status. `x00` = success, `x01` = write prot
 Takes a Little-endian uint32. Erases the whole 4KB in the specified address to 0xFF.
 Replies with `x8012` ack and a uint8 status. `x00` = success, `x01` = write protected.
 
-### Subcommand 0x20: Reset MCU
+### Subcommand 0x20: Reset NFC/IR MCU
 
-### Subcommand 0x21: Set MCU configuration
+### Subcommand 0x21: Set NFC/IR MCU configuration
 
 Write configuration data to MCU. This data can be IR configuration, NFC configuration or data for the 512KB MCU firmware update.
 
@@ -180,7 +181,7 @@ Takes 38 or 37 bytes long argument data.
 
 Replies with ACK `xA0` `x20` and 34 bytes of data.
 
-### Subcommand 0x22: Set MCU state
+### Subcommand 0x22: Set NFC/IR MCU state
 
 Takes one argument:
 
@@ -194,7 +195,7 @@ Takes one argument:
 
 Takes a 38 byte long argument.
 
-Sets a byte to `x01` (enable something?) and sets also an unknown data (configuration? for MCU?) to the bt device struct that copies it from given argument.
+Sets a byte to `x01` (enable something?) and sets also an unknown data (configuration? for NFC/IR MCU?) to the bt device struct that copies it from given argument.
 
 Replies with `x80 24 00` always.
 
@@ -204,7 +205,7 @@ Sets the above byte to `x00` (disable something?) and resets the previous 38 byt
 
 Replies with `x80 25 00` always.
 
-### Subcommand 0x28: Set unknown MCU data
+### Subcommand 0x28: Set unknown NFC/IR MCU data
 
 Takes a 38 byte long argument and copies it to unknown array_222640[96] at &array_222640[3].
 
@@ -212,7 +213,7 @@ Does the same job with OUTPUT report 0x12.
 
 Replies with ACK `x80` `x28`.
 
-### Subcommand 0x29: Get `x28` MCU data
+### Subcommand 0x29: Get `x28` NFC/IR MCU data
 
 Replies with ACK `xA8` `x29` and 34 bytes data, from a different buffer than the one the x28 writes.
 
@@ -226,7 +227,7 @@ Replies always with ACK `x00` `x2A`.
 
 `x00` as an ACK here is a bug. Devs forgot to add an ACK reply.
 
-### Subcommand 0x2B: Get `x29` MCU data
+### Subcommand 0x2B: Get `x29` NFC/IR MCU data
 
 Replies with ACK `xA9` `x2B` and 20 bytes long data (which has also a part from x24 subcmd).
 

--- a/bluetooth_hid_subcommands_notes.md
+++ b/bluetooth_hid_subcommands_notes.md
@@ -2,11 +2,11 @@
 
 ### Subcommand 0x##: All unused subcommands
 
-All subcommands that do nothing, reply back with ACK `x80` `x##` and `x03`
+All subcommands that do nothing, reply back with ACK `x80##` and `x03`
 
 ### Subcommand 0x00: Get Only Controller State
 
-Replies with `x80` `x00` `x03`
+Replies with `x8000` `x03`
 
 Can be used to get Controller state only (w/o 6-Axis sensor data), like any subcommand that does nothing
 
@@ -24,19 +24,19 @@ The procedure must be done sequentially:
 
 Host Pair request x01 (send HOST BT MAC and request Joy-Con BT MAC):
 
-| Byte # | Sample              | Remarks                                 |
-|:------:|:-------------------:| --------------------------------------- |
-|  0     | `01`                | subcmd                                  |
-|  1     | `01`                | Pair request type                       |
-|  2-7   | `16 30 AA 82 BB 98` | Host Bluetooth address in Little-Endian |
+| Byte # | Sample               | Remarks                                 |
+|:------:|:--------------------:| --------------------------------------- |
+|  0     | `x01`                | subcmd                                  |
+|  1     | `x01`                | Pair request type                       |
+|  2-7   | `x16 30 AA 82 BB 98` | Host Bluetooth address in Little-Endian |
 
 Joy-Con Pair request x01 reply:
 
-| Byte # | Sample              | Remarks                         |
-|:------:|:-------------------:| ------------------------------- |
-|  0     | `01`                | Pair request type               |
-|  1-6   | `57 30 EA 8A BB 7C` | Joy-Con BT MAC in Little-Endian |
-|  7-31  |                     | Descriptor?                     |
+| Byte # | Sample               | Remarks                         |
+|:------:|:--------------------:| ------------------------------- |
+|  0     | `x01`                | Pair request type               |
+|  1-6   | `x57 30 EA 8A BB 7C` | Joy-Con BT MAC in Little-Endian |
+|  7-31  |                      | Descriptor?                     |
 
 Host Pair request x03 (request LTK):
 
@@ -54,14 +54,14 @@ If the command is `x11`, it polls the MCU State? Used with IR Camera or NFC?
 
 Response data after 02 command byte:
 
-| Byte # | Sample              | Remarks                                                  |
-|:------:|:-------------------:| -------------------------------------------------------- |
-|  0-1   | `03 48`             | Firmware Version. Latest is 3.86 (from 4.0.0 and up).    |
-|  2     | `01`                | 1=Left Joy-Con, 2=Right Joy-Con, 3=Pro Controller.       |
-|  3     | `02`                | Unknown. Seems to be always `02`                         |
-|  4-9   | `7C BB 8A EA 30 57` | Joy-Con MAC address in Big Endian                        |
-|  10    | `01`                | Unknown. Seems to be always `01`                         |
-|  11    | `01`                | If `01`, colors in SPI are used. Otherwise default ones. |
+| Byte # | Sample               | Remarks                                                  |
+|:------:|:--------------------:| -------------------------------------------------------- |
+|  0-1   | `x03 48`             | Firmware Version. Latest is 3.86 (from 4.0.0 and up).    |
+|  2     | `x01`                | 1=Left Joy-Con, 2=Right Joy-Con, 3=Pro Controller.       |
+|  3     | `x02`                | Unknown. Seems to be always `02`                         |
+|  4-9   | `x7C BB 8A EA 30 57` | Joy-Con MAC address in Big Endian                        |
+|  10    | `x01`                | Unknown. Seems to be always `01`                         |
+|  11    | `x01`                | If `01`, colors in SPI are used. Otherwise default ones. |
 
 ### Subcommand 0x03: Set input report mode
 
@@ -408,13 +408,13 @@ The end result values are translated to `GPIO_PIN_OUTPUT_LOW = 0` and `GPIO_PIN_
 
 | Value # | PIN @Port 1 | GPIO Output Value    |
 |:-------:|:-----------:| -------------------- |
-| `0x00`  | `7`         | GPIO_PIN_OUTPUT_HIGH |
+| `x00`   | `7`         | GPIO_PIN_OUTPUT_HIGH |
 |         | `15`        | GPIO_PIN_OUTPUT_LOW  |
-| `0x04`  | `7`         | GPIO_PIN_OUTPUT_LOW  |
+| `x04`   | `7`         | GPIO_PIN_OUTPUT_LOW  |
 |         | `15`        | GPIO_PIN_OUTPUT_LOW  |
-| `0x10`  | `7`         | GPIO_PIN_OUTPUT_HIGH |
+| `x10`   | `7`         | GPIO_PIN_OUTPUT_HIGH |
 |         | `15`        | GPIO_PIN_OUTPUT_HIGH |
-| `0x14`  | `7`         | GPIO_PIN_OUTPUT_LOW  |
+| `x14`   | `7`         | GPIO_PIN_OUTPUT_LOW  |
 |         | `15`        | GPIO_PIN_OUTPUT_HIGH |
 
 Replies with ACK `x80` `x51`.

--- a/imu_sensor_notes.md
+++ b/imu_sensor_notes.md
@@ -2,17 +2,17 @@
 
 ## Packet data information
 
-If 6-axis sensor is enabled, the IMU data in an 0x30, 0x31, 0x32 and 0x33 input report is packaged like this (assuming the packet ID is located at byte -1):
+If 6-axis sensor is enabled, the IMU data in an 0x30, 0x31, 0x32 and 0x33 input report is packaged like this (assuming the packet ID is located at byte 0):
 
 | Byte       | Remarks                                                       |
 |:----------:| ------------------------------------------------------------- |
-|   12-13    | accel_x (Int16LE)                                             |
-|   14-15    | accel_y (Int16LE)                                             |
-|   16-17    | accel_z (Int16LE)                                             |
-|   18-19    | gyro_1 (Int16LE)                                              |
-|   20-21    | gyro_2 (Int16LE)                                              |
-|   22-23    | gyro_3 (Int16LE)                                              |
-|   24-47    | The data is repeated 2 more times. Each with 5ms Δt sampling. |
+|   13-14    | accel_x (Int16LE)                                             |
+|   15-16    | accel_y (Int16LE)                                             |
+|   17-18    | accel_z (Int16LE)                                             |
+|   19-20    | gyro_1 (Int16LE)                                              |
+|   21-22    | gyro_2 (Int16LE)                                              |
+|   23-24    | gyro_3 (Int16LE)                                              |
+|   25-48    | The data is repeated 2 more times. Each with 5ms Δt sampling. |
 
 The 6-Axis data is repeated 3 times. On Joy-con with a 15ms packet push, this is translated to 5ms difference sampling. E.g. 1st sample 0ms, 2nd 5ms, 3rd 10ms. Using all 3 samples let you have a 5ms precision instead of 15ms.
 

--- a/rumble_data_table.md
+++ b/rumble_data_table.md
@@ -35,6 +35,8 @@ byte[3] = lf_amp & 0xFF;
 
 ## Frequency Table
 
+Values # are in HEX.
+
 | HF Byte 0-1 # | LF Byte 3 # | Frequency (Hz) | Frequency Rounded (Hz) |
 |:--:|:---:|:---:|:---:|
 |		|	`01`	|	40.875885	|	41	|

--- a/spi_flash_notes.md
+++ b/spi_flash_notes.md
@@ -11,7 +11,7 @@
 | Pairing info (factory2) | `x4000` | `x1000` | Empty. (Dev-units use it?)                                           |
 | Shipment                | `x5000` | `x1000` | Only first byte is used                                              |
 | Config and calibration  | `x6000` | `xA000` | Stores Factory configuration and calibration, user calibration       |
-| PatchRAM section        | `x10000`| `x70000 | Stores Broadcom PatchRAMs, by default @0x10000 and @0x28000          |
+| PatchRAM section        | `x10000`| `x70000`| Stores Broadcom PatchRAMs, by default @0x10000 and @0x28000          |
 
 ## x0000: Initial PatchRAM
 
@@ -19,12 +19,12 @@ Initial PatchRAM section starts at `x0000` and ends at `x03B0`. Has a total of 1
 
 Includes Magic numbers, OTA FW DS1 address and code that loads the PatchRAM @0x10000 or @0x28000 by checking the 0xx1ff4 address.
 
-|    Range        |        Sample                      | Remarks                                             |
-|:---------------:|:----------------------------------:| --------------------------------------------------- |
-| `x0000`-`x0010` | `01 08 00 F0 00 00 62 08 C0 5D 89` | Loader Magic or it sends x895DC008 @x620000F0 MMIO  |
-| `x0012`-`x001A` | `40 0600 x5730EA8ABB7C`            | BD_ADDR type record, in LE (7C:BB:8A:EA:30:57)      |
-| `x001B`-`x03AF` | ---                                | Initial code that loads one of the main PatchRAM    |
-| `x03B0`-`x03B7` | `02 0A 00000100 00200000 0010`     | DS1 Uint32LE (`x010000`) and 2 values (x200, x1000) |
+|    Range        |        Sample                       | Remarks                                             |
+|:---------------:|:-----------------------------------:| --------------------------------------------------- |
+| `x0000`-`x0010` | `x01 08 00 F0 00 00 62 08 C0 5D 89` | Loader Magic or it sends x895DC008 @x620000F0 MMIO  |
+| `x0012`-`x001A` | `x40 0600 x5730EA8ABB7C`            | BD_ADDR type record, in LE (7C:BB:8A:EA:30:57)      |
+| `x001B`-`x03AF` | ---                                 | Initial code that loads one of the main PatchRAM    |
+| `x03B0`-`x03B7` | `x02 0A 00000100 00200000 0010`     | DS1 Uint32LE (`x010000`) and 2 values (x200, x1000) |
 
 ## x1000 Failsafe mechanism
 
@@ -91,7 +91,7 @@ The first byte is probably set to x1 on new Joy-Con. Switch makes sure to set it
 
 |  Section Range  | Subsection Range | Remarks                                                                 |
 |:---------------:|:----------------:| ----------------------------------------------------------------------- |
-| `x6000`-`x600F` | -------------    | Serial number in non-extended ASCII. If first byte is >= `80`, no S/N. If a byte is `00` `NUL`, skip. Max 15 chars, if 16 chars last one is skipped.|
+| `x6000`-`x600F` | -------------    | Serial number in non-extended ASCII. If first byte is >= `x80`, no S/N. If a byte is `00` `NUL`, skip. Max 15 chars, if 16 chars last one is skipped.|
 | `x6012`         | -------------    | Device type. JC (L): `x01`, JC (R): `x02`, Pro: `x03`. Only the 3 LSB are accounted for. Used internally and for `x02` subcmd. |
 | `x6013`         | -------------    | Unknown, seems to always be `xA0`                                       |
 | `x601B`         | -------------    | Color info exists if `x01`. If 0, default colors used are ARGB `#55555555`, `#FFFFFFFF`. Used for `x02` subcmd. |


### PR DESCRIPTION
Changes the byte orders to include the report id as byte 0 for easier bt packet parsing when developing.
Explain that the MCU is actually the NFC/IR MCU and not the SoC.
This fixes all hex values to include an 'x' to distinguish them.
